### PR TITLE
Fix versionutils.is_compatible to not raise RuntimeWarning

### DIFF
--- a/oslo_utils/versionutils.py
+++ b/oslo_utils/versionutils.py
@@ -46,7 +46,7 @@ def is_compatible(requested_version, current_version, same_major=True):
     requested_parts = pkg_resources.parse_version(requested_version)
     current_parts = pkg_resources.parse_version(current_version)
 
-    if same_major and (requested_parts[0] != current_parts[0]):
+    if same_major and (requested_parts.base_version[0] != current_parts.base_version[0]):
         return False
 
     return current_parts >= requested_parts


### PR DESCRIPTION
Fixes versionutils.is_compatible so pkg_resource wouldn't raise RuntimeWarning:
/pkg_resources/__init__.py:187: RuntimeWarning: You have iterated over the result of pkg_resources.parse_version. This is a legacy behavior which is inconsistent with the new version class introduced in setuptools 8.0. In most cases, conversion to a tuple is unnecessary. For comparison of versions, sort the Version instances directly. If you have another use case requiring the tuple, please file a bug with the setuptools project describing that need.